### PR TITLE
added anchors to loot_num scene

### DIFF
--- a/project/scenes/loot_num.tscn
+++ b/project/scenes/loot_num.tscn
@@ -36,7 +36,19 @@ libraries = {
 shape = SubResource("CircleShape2D_u302n")
 
 [node name="Label" type="Label" parent="Area2D"]
-offset_right = 40.0
-offset_bottom = 23.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -10.0
+offset_top = -6.0
+offset_right = 30.0
+offset_bottom = 17.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(0.5, 0.5)
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]


### PR DESCRIPTION
loot_nums can now be numbers from 0 to 999 (inclusive). Achieved this by using label node instead of sprite2d node